### PR TITLE
docs: add SECURITY.md with vulnerability reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| latest  | ✅                 |
+| < 1.0   | ❌                 |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+To report a security vulnerability, please open a [GitHub Security Advisory](https://github.com/Bengerthelorf/macIconChanger/security/advisories/new).
+
+Include as much of the following information as possible:
+
+- Type of issue (e.g. privilege escalation, path traversal, code injection)
+- Full path of the source file(s) related to the issue
+- Location of the affected source code (tag/branch/commit or direct URL)
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit it
+
+You can expect an acknowledgement within **48 hours** and a more detailed response within **5 business days**.
+
+## Security Considerations
+
+macIconChanger requires administrator privileges to replace application icons stored
+in system directories. Please only download releases from the official
+[GitHub Releases](https://github.com/Bengerthelorf/macIconChanger/releases) page
+or via the official [Homebrew tap](https://github.com/Bengerthelorf/homebrew-tap).


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` file so GitHub surfaces a "Report a vulnerability" button in the Security tab and directs reporters away from public issues.

## Contents

- Supported versions table
- Instructions to use GitHub Security Advisories (private disclosure)
- What information to include in a report
- Response time expectations (48 h ack, 5 days detailed response)
- A note about only downloading from official releases / Homebrew tap

No code changes.
